### PR TITLE
Parse merchant container and pass to localstorage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -538,7 +538,6 @@ module.exports = {
         'prefer-destructuring': 'off',
         'prefer-numeric-literals': 'error',
         'prefer-promise-reject-errors': 'error',
-        'require-await': 'error',
         'rest-spread-spacing': 'error',
         'semi-style': 'error',
         'sort-keys': 'off',

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,6 +1,6 @@
 /* @flow */
 export default {
-  'oneDay': 1000 * 60 * 60 * 24,
+  'oneHour': 1000 * 60 * 60,
   'sevenDays': 1000 * 60 * 60 * 24 * 7,
   'oneMonth': 1000 * 60 * 60 * 24 * 30,
   'accessTokenUrl': 'https://www.paypal.com/muse/api/partner-token',

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,5 +1,6 @@
 /* @flow */
 export default {
+  'oneDay': 1000 * 60 * 60 * 24,
   'sevenDays': 1000 * 60 * 60 * 24 * 7,
   'oneMonth': 1000 * 60 * 60 * 24 * 30,
   'accessTokenUrl': 'https://www.paypal.com/muse/api/partner-token',

--- a/src/lib/get-property-id.js
+++ b/src/lib/get-property-id.js
@@ -12,11 +12,11 @@ import { getPropertyId, setPropertyId, setContainer, getValidContainer } from '.
 /* Takes the full container and transforms it into
 a format better suited for use by the SDK */
 const parseContainer = (container : Container) : ContainerSummary => {
-  const offerTag = container.tags.find(tag => tag.tag_definition_id === 'offers');
+  const offerTag = container.tags.filter(tag => tag.tag_definition_id === 'offers')[0];
   let storeCashProgramId;
 
   if (offerTag && offerTag.configuration) {
-    storeCashProgramId = offerTag.configuration.find(config => config.id === 'offer-program-id');
+    storeCashProgramId = offerTag.configuration.filter(config => config.id === 'offer-program-id')[0];
     storeCashProgramId = storeCashProgramId ? storeCashProgramId.value : null;
   } else {
     storeCashProgramId = null;
@@ -46,7 +46,7 @@ const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> =>
     });
 };
 
-export const fetchPropertyId = ({ paramsToPropertyIdUrl } : Config) : Promise<string> => {
+export const fetchPropertyId = ({ paramsToPropertyIdUrl, propertyId } : Config) : Promise<string> => {
   const cachedPropertyId = getPropertyId();
 
   if (cachedPropertyId) {
@@ -57,8 +57,13 @@ export const fetchPropertyId = ({ paramsToPropertyIdUrl } : Config) : Promise<st
     .then(parseContainer)
     .then(containerSummary => {
       // save to localstorage
-      setPropertyId(containerSummary.id);
       setContainer(containerSummary);
+
+      if (propertyId) {
+        setPropertyId(propertyId);
+      } else {
+        setPropertyId(containerSummary.id);
+      }
 
       return containerSummary.id;
     })
@@ -68,19 +73,24 @@ export const fetchPropertyId = ({ paramsToPropertyIdUrl } : Config) : Promise<st
     });
 };
 
-export const fetchContainerSettings = () : Promise<ContainerSummary> => {
+export const fetchContainerSettings = ({ paramsToPropertyIdUrl, propertyId } : Config) : Promise<ContainerSummary> => {
   const cachedContainer = getValidContainer();
 
   if (cachedContainer) {
     return Promise.resolve(cachedContainer);
   }
 
-  return getContainer()
+  return getContainer(paramsToPropertyIdUrl)
     .then(parseContainer)
     .then(containerSummary => {
       // save to localstorage
-      setPropertyId(containerSummary.id);
       setContainer(containerSummary);
+
+      if (propertyId) {
+        setPropertyId(propertyId);
+      } else {
+        setPropertyId(containerSummary.id);
+      }
 
       return containerSummary;
     })

--- a/src/lib/local-storage/container.js
+++ b/src/lib/local-storage/container.js
@@ -1,0 +1,39 @@
+/* @flow */
+import constants from '../constants';
+import type { ContainerSummary } from '../../types';
+
+const { storage, oneDay } = constants;
+
+const getContainer = () : Object | null => {
+  const storedValue = window.localStorage.getItem(storage.paypalCrContainer);
+
+  if (storedValue) {
+    return JSON.parse(storedValue);
+  }
+
+  return null;
+};
+
+/* Returns an existing, non-expired container. Removes a container
+from localstorage if it has expired. */
+export const getValidContainer = () : ContainerSummary | null => {
+  const storedValue = getContainer();
+  const now = Date.now();
+
+  if (!storedValue || ((now - storedValue.createdAt) > oneDay)) {
+    window.localStorage.removeItem(storage.paypalCrContainer);
+
+    return null;
+  }
+
+  return storedValue.containerSummary;
+};
+
+export const setContainer = (containerSummary : ContainerSummary) => {
+  const storedValue = {
+    containerSummary,
+    createdAt: Date.now()
+  };
+
+  window.localStorage.setItem(storage.paypalCrContainer, storedValue);
+};

--- a/src/lib/local-storage/container.js
+++ b/src/lib/local-storage/container.js
@@ -2,7 +2,7 @@
 import constants from '../constants';
 import type { ContainerSummary } from '../../types';
 
-const { storage, oneDay } = constants;
+const { storage, oneHour } = constants;
 
 const getContainer = () : Object | null => {
   const storedValue = window.localStorage.getItem(storage.paypalCrContainer);
@@ -20,7 +20,7 @@ export const getValidContainer = () : ContainerSummary | null => {
   const storedValue = getContainer();
   const now = Date.now();
 
-  if (!storedValue || ((now - storedValue.createdAt) > oneDay)) {
+  if (!storedValue || ((now - storedValue.createdAt) > oneHour)) {
     window.localStorage.removeItem(storage.paypalCrContainer);
 
     return null;
@@ -30,10 +30,10 @@ export const getValidContainer = () : ContainerSummary | null => {
 };
 
 export const setContainer = (containerSummary : ContainerSummary) => {
-  const storedValue = {
+  const storedValue = JSON.stringify({
     containerSummary,
     createdAt: Date.now()
-  };
+  });
 
   window.localStorage.setItem(storage.paypalCrContainer, storedValue);
 };

--- a/src/lib/local-storage/index.js
+++ b/src/lib/local-storage/index.js
@@ -15,3 +15,5 @@ export {
 } from './user';
 
 export { getPropertyId, setPropertyId } from './property-id';
+
+export { setContainer, getValidContainer } from './container';

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -25,7 +25,7 @@ import {
   getOrCreateValidUserId,
   setMerchantProvidedUserId
 } from './lib/local-storage';
-import { fetchPropertyId } from './lib/get-property-id';
+import { fetchContainerSettings } from './lib/get-property-id';
 import getJetlore from './lib/jetlore';
 import trackFpti from './lib/fpti';
 import { track } from './lib/track';
@@ -152,16 +152,16 @@ export const clearTrackQueue = (config : Config) => {
 };
 
 export const setImplicitPropertyId = (config : Config) => {
-  /*
-    ** this is used for backwards compatibility
-    ** we do not want to overwrite a propertyId if propertyId
-    ** has already been set using the SDK
-    */
-  if (config.propertyId) {
-    return;
-  }
-  fetchPropertyId(config).then(propertyId => {
-    config.propertyId = propertyId;
+
+  fetchContainerSettings(config).then(containerSummary => {
+    /* this is used for backwards compatibility we do not want to overwrite
+    a propertyId if propertyId has already been set using the SDK */
+    if (!config.propertyId) {
+      config.propertyId = containerSummary.id;
+    }
+
+    config.containerSummary = containerSummary;
+
     if (trackEventQueue.length) {
       clearTrackQueue(config);
     }

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -1,5 +1,6 @@
 /* @flow */
 import type { UserData  } from './user';
+import type { ContainerSummary } from './container';
 import type {
   ParamsToBeaconUrl,
   ParamsToTokenUrl,
@@ -18,6 +19,7 @@ export type Config = {|
         div? : string,
         lang? : string
     |},
+    containerSummary? : ContainerSummary | null,
     paramsToPropertyIdUrl? : ParamsToPropertyIdUrl,
     currencyCode? : string
 |};

--- a/src/types/container.js
+++ b/src/types/container.js
@@ -1,8 +1,39 @@
 /* @flow */
+type config = {|
+  config_required : boolean,
+  config_type : string,
+  config_value : string,
+  id : string,
+  name : string,
+  value : string
+|};
+
+type tag = {|
+  configuration : $ReadOnlyArray<config>,
+  enabled : boolean,
+  id : string,
+  tag_definition_id : string,
+  time_created : string,
+  time_updated : string
+|};
+
+/* A JSON description of the different products/tags that are
+loaded on a merchant site when pptm is pulled from a script tag. */
 export type Container = {|
-  id : string
+  /* container id is used as propertyId */
+  id : string,
+  /* 'xo' or 'manual'. 'xo' containers are created automatically
+  for any merchant site that features a smart payment button. */
+  integration_type : string,
+  /* Merchant encrypted account number */
+  owner_id : string,
+  /* Array containing different elements to load. */
+  tags : $ReadOnlyArray<tag>
 |};
 
 export type ContainerSummary = {|
-
+  id : string,
+  integrationType : string,
+  mrid : string,
+  storeCashProgramId : string | null
 |};

--- a/test/get-property-id.test.js
+++ b/test/get-property-id.test.js
@@ -1,0 +1,117 @@
+/* @flow */
+/* global it describe beforeEach afterAll afterEach expect jest */
+import { fetchContainerSettings } from '../src/lib/get-property-id';
+import { getPropertyId, getValidContainer, setContainer } from '../src/lib/local-storage';
+
+import { mockContainer1 } from './mocks';
+
+global.fetch = jest.fn().mockImplementation(async () => {
+  return {
+    status: 200,
+    json: () => mockContainer1
+  };
+});
+
+jest.mock('@paypal/sdk-client/src', () => {
+  return { getMerchantID: jest.fn().mockImplementation(() => [ mockContainer1.owner_id ]) };
+});
+
+describe('get-property-id', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('fetchContainerSettings', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('requests a container using merchantId and browser location', async (done) => {
+      const expectedUrl = 'https://www.paypal.com/tagmanager/containers/xo?mrid=759SBALRW3ZTY&url=http%3A%2F%2Flocalhost';
+      await fetchContainerSettings({});
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith(expectedUrl);
+      done();
+    });
+
+    it('returns an abridged summary of a merchant container', async (done) => {
+      const expected = {
+        id: mockContainer1.id,
+        integrationType: mockContainer1.integration_type,
+        mrid: mockContainer1.owner_id,
+        storeCashProgramId: 'C4ENKKFUEUJ4J'
+      };
+
+      const result = await fetchContainerSettings({});
+
+      expect(result).toEqual(expected);
+      done();
+    });
+
+    it('will use the merchant-provided propertyId if one is provided', async (done) => {
+      const expectedPropertyId = 'arglebargleflimflam';
+      const expectedSummary = {
+        id: mockContainer1.id,
+        integrationType: mockContainer1.integration_type,
+        mrid: mockContainer1.owner_id,
+        storeCashProgramId: 'C4ENKKFUEUJ4J'
+      };
+
+      const resultSummary = await fetchContainerSettings({ propertyId: 'arglebargleflimflam' });
+      let resultPropertyId = getPropertyId();
+      resultPropertyId = resultPropertyId && resultPropertyId.propertyId;
+
+      expect(resultSummary).toEqual(expectedSummary);
+      expect(resultPropertyId).toBe(expectedPropertyId);
+      done();
+    });
+
+    it('saves the container summary to localstorage', async (done) => {
+      const expected = {
+        id: mockContainer1.id,
+        integrationType: mockContainer1.integration_type,
+        mrid: mockContainer1.owner_id,
+        storeCashProgramId: 'C4ENKKFUEUJ4J'
+      };
+
+      await fetchContainerSettings({});
+
+      const result = getValidContainer();
+
+      expect(result).toEqual(expected);
+      done();
+    });
+
+    it('saves the containerId to localstorage as a propertyId', async (done) => {
+      const expected = mockContainer1.id;
+
+      await fetchContainerSettings({});
+
+      let result = getPropertyId();
+      result = result && result.propertyId;
+
+      expect(result).toEqual(expected);
+      done();
+    });
+    
+    it('will return a container summary from localstorage if it exists and is less than one hour old', async (done) => {
+      const expected = {
+        id: 'a-totally-new-id',
+        integrationType: 'manual',
+        mrid: 'totatty-different-mrid',
+        storeCashProgramId: 'a-program-id'
+      };
+
+      setContainer(expected);
+      const result = await fetchContainerSettings({});
+
+      expect(result).toEqual(expected);
+      done();
+    });
+  });
+});

--- a/test/mocks/index.js
+++ b/test/mocks/index.js
@@ -1,0 +1,2 @@
+/* @flow */
+export { mockContainer1, mockContainerSummary1 } from './mock-container';

--- a/test/mocks/mock-container.js
+++ b/test/mocks/mock-container.js
@@ -1,0 +1,194 @@
+/* @flow */
+export const mockContainer1 = {
+  'id': '475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079',
+  'owner_type': 'PAYPAL',
+  'owner_id': '759SBALRW3ZTY',
+  'integration_type': 'XO',
+  'application_context': {
+    'bn_code': 'CHECKOUT_BUTTON',
+    'partner_name': 'CHECKOUT_BUTTON',
+    'merchant_country': 'US'
+  },
+  'url': 'tomoconnell.dev',
+  'published': true,
+  'tags': [
+    {
+      'id': '2eae7800-291c-43d9-976f-9e6953f0e40c',
+      'tag_definition_id': 'analytics-xo',
+      'enabled': true,
+      'configuration': [
+        {
+          'id': 'analytics-id',
+          'name': 'Merchant + website unique analytics tracking id',
+          'config_value': '',
+          'config_type': 'string',
+          'config_required': true,
+          'value': '759SBALRW3ZTY-1'
+        }
+      ],
+      'time_created': '2019-10-08T23:28:46.591Z',
+      'time_updated': '2019-10-08T23:31:11.032Z'
+    },
+    {
+      'id': '64e55e78-993f-437b-b545-13936e7f7a5c',
+      'tag_definition_id': 'offers',
+      'enabled': true,
+      'configuration': [
+        {
+          'id': 'analytics-id',
+          'name': 'Merchant + website unique analytics tracking id',
+          'config_value': '',
+          'config_type': 'string',
+          'config_required': true,
+          'value': '759SBALRW3ZTY-1'
+        },
+        {
+          'id': 'variant',
+          'name': 'Variant name',
+          'config_value': 'toast',
+          'config_type': 'string',
+          'config_required': true,
+          'value': 'toast'
+        },
+        {
+          'id': 'flow',
+          'name': 'Flow name',
+          'config_value': 'offer',
+          'config_type': 'string',
+          'config_required': true,
+          'value': 'store-cash'
+        },
+        {
+          'id': 'mobile-variant',
+          'name': 'Mobile variant name',
+          'config_value': 'mobile-toast',
+          'config_type': 'string',
+          'config_required': true,
+          'value': 'mini-slide-up'
+        },
+        {
+          'id': 'mobile-flow',
+          'name': 'Mobile flow name',
+          'config_value': 'offer',
+          'config_type': 'string',
+          'config_required': true,
+          'value': 'store-cash'
+        },
+        {
+          'id': 'limit',
+          'name': 'Number of times the credit banner is shown per day',
+          'config_value': '3',
+          'config_type': 'number',
+          'config_required': false,
+          'value': '3'
+        },
+        {
+          'id': 'is-mobile-enabled',
+          'name': 'Mobile Enabled',
+          'config_value': true,
+          'config_type': 'boolean',
+          'config_required': false,
+          'value': 'true'
+        },
+        {
+          'id': 'is-desktop-enabled',
+          'name': 'Desktop Enabled',
+          'config_value': true,
+          'config_type': 'boolean',
+          'config_required': false,
+          'value': 'true'
+        },
+        {
+          'id': 'offer-program-id',
+          'name': 'Offer Program ID',
+          'config_value': '',
+          'config_type': 'string',
+          'config_required': false,
+          'value': 'C4ENKKFUEUJ4J'
+        },
+        {
+          'id': 'is-onsite-experience-enabled',
+          'name': 'Onsite Experience enabled',
+          'config_value': true,
+          'config_type': 'boolean',
+          'config_required': false,
+          'value': 'true'
+        }
+      ],
+      'time_created': '2019-10-08T23:31:11.032Z',
+      'time_updated': '2019-10-08T23:31:11.032Z'
+    }
+  ],
+  'time_created': '2019-10-08T23:28:46.591Z',
+  'time_updated': '2019-10-08T23:31:11.033Z',
+  'links': [
+    {
+      'rel': 'get',
+      'href': 'https://msmaster.qa.paypal.com:22469/v1/offers/containers/475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079',
+      'method': 'GET'
+    },
+    {
+      'rel': 'update',
+      'href': 'https://msmaster.qa.paypal.com:22469/v1/offers/containers/475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079',
+      'method': 'PUT'
+    },
+    {
+      'rel': 'delete',
+      'href': 'https://msmaster.qa.paypal.com:22469/v1/offers/containers/475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079',
+      'method': 'DELETE'
+    },
+    {
+      'rel': 'add-tag',
+      'href': 'https://msmaster.qa.paypal.com:22469/v1/offers/containers/475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079/tags',
+      'method': 'POST'
+    },
+    {
+      'rel': 'get-tags',
+      'href': 'https://msmaster.qa.paypal.com:22469/v1/offers/containers/475d4fff-dc57-4fd3-a6e2-ae1aa2f1f079/tags',
+      'method': 'GET'
+    }
+  ],
+  'sys': {
+    'links': {
+      'jsBaseUrl': '/tagmanager/js',
+      'cssBaseUrl': '/tagmanager/css',
+      'templateBaseUrl': '/tagmanager/templates/US/en',
+      'resourceBaseUrl': '/tagmanager',
+      'originalTemplateBaseUrl': '/tagmanager/templates'
+    },
+    'pageInfo': {
+      'date': 'Oct 8, 2019 16:33:29 -07:00',
+      'hostName': 'rZJvnqaaQhLn/nmWT8cSUsC2av9vPD3/nSVKK9CG5lUOuM4ZjhQlnw',
+      'rlogId': 'rZJvnqaaQhLn%2FnmWT8cSUnIqeOCL0tUDhRbFiJtwz9JU2svSPnQ0ja%2BcJ%2B%2FEhu5mPb3h%2FUaMkmI_16dadb87129',
+      'script': 'node',
+      'debug': {
+        'scm': 'ERROR: scm info not found in manifest.json'
+      }
+    },
+    'locality': {
+      'timezone': {
+        'determiner': 'viaCowPrimary',
+        'value': 'America/Los_Angeles'
+      },
+      'country': 'US',
+      'locale': 'en_US',
+      'language': 'en',
+      'directionality': 'ltr'
+    },
+    'tracking': {
+      'fpti': {
+        'name': 'pta',
+        'jsURL': 'https://www.paypalobjects.com/staging',
+        'serverURL': 'https://tracking.qa.paypal.com/webapps/tracking/ts',
+        'dataString': 'pgrp=tagmanagernodeweb%2Fpublic%2Ftemplates%2F.dust&page=tagmanagernodeweb%2Fpublic%2Ftemplates%2F.dust&tmpl=tagmanagernodeweb%2Fpublic%2Ftemplates%2F.dust&pgst=1570577609001&calc=084591903b3eb&rsta=en_US&pgtf=Nodejs&s=ci&csci=176304afab2f42c99a15f07945d7ae1e&comp=tagmanagernodeweb&tsrce=tagmanagernodeweb&cu=0'
+      }
+    }
+  }
+};
+
+export const mockContainerSummary1 = {
+  id: mockContainer1.id,
+  integrationType: mockContainer1.integration_type,
+  mrid: mockContainer1.owner_id,
+  storeCashProgramId: 'C4ENKKFUEUJ4J'
+};

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -4,7 +4,7 @@ import { Tracker } from '../src/tracker-component';
 import constants from '../src/lib/constants';
 // $FlowFixMe
 import generateIdModule from '../src/lib/generate-id';
-import { getUserId, getCartId } from '../src/lib/local-storage';
+import { getUserId, getCartId, setPropertyId } from '../src/lib/local-storage';
 
 const { sevenDays, storage } = constants;
 
@@ -725,7 +725,7 @@ describe('paypal.Tracker', () => {
   it('should not fetch implicit propertyId route if one is not provided and propertyid is cached', () => {
     const email = '__test__email3@gmail.com';
     const userName = '__test__userName3';
-
+    setPropertyId('arglebargleflimflam')
     Tracker({ user: { email, name: userName } });
     expect(createElementCalls).toBe(0);
     expect(fetchCalls.length).toBe(0);

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -4,7 +4,7 @@ import { Tracker } from '../src/tracker-component';
 import constants from '../src/lib/constants';
 // $FlowFixMe
 import generateIdModule from '../src/lib/generate-id';
-import { getUserId, getCartId, setPropertyId } from '../src/lib/local-storage';
+import { getUserId, getCartId } from '../src/lib/local-storage';
 
 const { sevenDays, storage } = constants;
 
@@ -237,7 +237,7 @@ describe('paypal.Tracker', () => {
     const userName = '__test__userName4';
     const tracker = Tracker({ user: { email, name: userName } });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.addToCart({
       cartId: '__test__cartId0',
       items: [
@@ -297,7 +297,7 @@ describe('paypal.Tracker', () => {
         version: 'TRANSITION_FLAG'
       })
     );
-    expect(createElementCalls).toBe(2);
+    expect(createElementCalls).toBe(3);
   });
 
   it('should send removeFromCart events', () => {
@@ -305,7 +305,7 @@ describe('paypal.Tracker', () => {
     const userName = '__test__userName5';
     const tracker = Tracker({ user: { email, name: userName } });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.removeFromCart({
       currencyCode: 'LARGE_SHINY_ROCKS',
       cartId: '__test__cartId',
@@ -341,7 +341,7 @@ describe('paypal.Tracker', () => {
         version: 'TRANSITION_FLAG'
       })
     );
-    expect(createElementCalls).toBe(1);
+    expect(createElementCalls).toBe(2);
   });
 
   it('should send purchase events', () => {
@@ -349,7 +349,7 @@ describe('paypal.Tracker', () => {
     const userName = '__test__userName6';
     const tracker = Tracker({ currencyCode: 'COWRIESHELLS', user: { email, name: userName } });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.purchase({
       currencyCode: 'USD',
       cartId: '__test__cartId'
@@ -371,7 +371,7 @@ describe('paypal.Tracker', () => {
         version: 'TRANSITION_FLAG'
       })
     );
-    expect(createElementCalls).toBe(1);
+    expect(createElementCalls).toBe(2);
   });
 
   it('should send cancelCart events and clear localStorage upon cancelling cart', () => {
@@ -379,7 +379,7 @@ describe('paypal.Tracker', () => {
     const userName = '__test__userName7';
     const tracker = Tracker({ currencyCode: 'COWRIESHELLS', user: { email, name: userName } });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.cancelCart();
     expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
       JSON.stringify({
@@ -398,7 +398,7 @@ describe('paypal.Tracker', () => {
         version: 'TRANSITION_FLAG'
       })
     );
-    expect(createElementCalls).toBe(1);
+    expect(createElementCalls).toBe(2);
 
     const afterStorage = JSON.parse(window.localStorage.getItem(storage.paypalCrCart));
 
@@ -417,12 +417,12 @@ describe('paypal.Tracker', () => {
       paramsToBeaconUrl
     });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.purchase({
       cartId: '__test__cartId'
     });
     expect(imgMock.src).toBe('https://example.com/picture');
-    expect(createElementCalls).toBe(1);
+    expect(createElementCalls).toBe(2);
     expect(JSON.stringify(calledArgs)).toEqual(
       JSON.stringify([
         {
@@ -452,9 +452,9 @@ describe('paypal.Tracker', () => {
     const email = '__test__email9';
     const tracker = Tracker();
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
-    tracker.setUser({ user: { name: userName, email } });
     expect(createElementCalls).toBe(1);
+    tracker.setUser({ user: { name: userName, email } });
+    expect(createElementCalls).toBe(2);
     expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
       JSON.stringify({
         currencyCode: 'USD',
@@ -482,7 +482,7 @@ describe('paypal.Tracker', () => {
       }
     });
     tracker.setPropertyId(propertyId);
-    expect(createElementCalls).toBe(0);
+    expect(createElementCalls).toBe(1);
     tracker.setUser({
       user: {
         id: 'bar',
@@ -490,7 +490,7 @@ describe('paypal.Tracker', () => {
         name: '__test__name'
       }
     });
-    expect(createElementCalls).toBe(1);
+    expect(createElementCalls).toBe(2);
     const dataParamObject = extractDataParam(imgMock.src);
     // $FlowFixMe
     expect(JSON.stringify(dataParamObject)).toBe(
@@ -678,7 +678,7 @@ describe('paypal.Tracker', () => {
     // viewPage will have been called once at the time the tracker is itialized
     expect(createElementCalls).toBe(1);
     tracker.setPropertyId(propertyId);
-    expect(fetchCalls.length).toBe(0);
+    expect(fetchCalls.length).toBe(1);
     tracker.addToCart({
       cartId: '__test__cartId',
       items: [
@@ -722,15 +722,6 @@ describe('paypal.Tracker', () => {
     expect(createElementCalls).toBe(2);
   });
 
-  it('should not fetch implicit propertyId route if one is not provided and propertyid is cached', () => {
-    const email = '__test__email3@gmail.com';
-    const userName = '__test__userName3';
-    setPropertyId('arglebargleflimflam')
-    Tracker({ user: { email, name: userName } });
-    expect(createElementCalls).toBe(0);
-    expect(fetchCalls.length).toBe(0);
-  });
-
   it('should fetch implicit propertyId route if one is not provided', () => {
     const email = '__test__email3@gmail.com';
     const userName = '__test__userName3';
@@ -741,16 +732,6 @@ describe('paypal.Tracker', () => {
     expect(createElementCalls).toBe(0);
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0][0]).toBe('https://www.paypal.com/tagmanager/containers/xo?mrid=xyz&url=http%3A%2F%2Flocalhost');
-  });
-
-  it('should not fetch propertyId if one is provided', () => {
-    const email = '__test__email3@gmail.com';
-    const userName = '__test__userName3';
-    // clear local storage to ensure a request happens
-    window.localStorage.removeItem(storage.paypalCrPropertyId);
-
-    Tracker({ user: { email, name: userName }, propertyId: 'hello' });
-    expect(fetchCalls.length).toBe(0);
   });
 
   it('should gracefully fail in the event that malformed data exists in local storage', () => {

--- a/test/tracker/add-to-cart.test.js
+++ b/test/tracker/add-to-cart.test.js
@@ -3,13 +3,14 @@
 import { Tracker } from '../../src/tracker-component';
 import { track } from '../../src/lib/track';
 import { fetchPropertyId } from '../../src/lib/get-property-id';
+import { mockContainerSummary1 } from '../mocks';
 // eslint-disable-next-line no-console
 console.error = jest.fn();
 jest.mock('../../src/lib/track');
 jest.mock('../../src/lib/get-property-id', () => {
   return {
-    // eslint-disable-next-line require-await
-    fetchPropertyId: async () => 'mockpropertyidofsomekind'
+    fetchPropertyId: async () => 'mockpropertyidofsomekind',
+    fetchContainerSettings: async () => mockContainerSummary1
   };
 });
 

--- a/test/tracker/remove-from-cart.test.js
+++ b/test/tracker/remove-from-cart.test.js
@@ -3,12 +3,13 @@
 import { Tracker } from '../../src/tracker-component';
 import { track } from '../../src/lib/track';
 import { fetchPropertyId } from '../../src/lib/get-property-id';
+import { mockContainerSummary1 } from '../mocks';
 
 jest.mock('../../src/lib/track');
 jest.mock('../../src/lib/get-property-id', () => {
   return {
-    // eslint-disable-next-line require-await
-    fetchPropertyId: async () => 'mockpropertyidofsomekind'
+    fetchPropertyId: async () => 'mockpropertyidofsomekind',
+    fetchContainerSettings: async () => mockContainerSummary1
   };
 });
 

--- a/test/tracker/set-user.test.js
+++ b/test/tracker/set-user.test.js
@@ -5,12 +5,13 @@ import { fetchPropertyId } from '../../src/lib/get-property-id';
 import { getUserId } from '../../src/lib/local-storage';
 import { track } from '../../src/lib/track';
 import constants from '../../src/lib/constants';
+import { mockContainerSummary1 } from '../mocks';
 
 jest.mock('../../src/lib/track');
 jest.mock('../../src/lib/get-property-id', () => {
   return {
-    // eslint-disable-next-line require-await
-    fetchPropertyId: async () => 'mockpropertyidofsomekind'
+    fetchPropertyId: async () => 'mockpropertyidofsomekind',
+    fetchContainerSettings: async () => mockContainerSummary1
   };
 });
 


### PR DESCRIPTION
- Parses the container returned by tagmanager into a simpler format. (see "parseContainer")
- Creates utility methods for reading/writing "ContainerSummary" from local storage.
- Updates tests to account for "pageView" triggering requests on load. (tests were previously hard-coded to expect '0', '1' requests. These values have been modified +1)
- Adds tests/mocks for new "fetchContainerSettings" method.